### PR TITLE
Add kicks in calc_trajectory

### DIFF
--- a/fieldmaptrack/track.py
+++ b/fieldmaptrack/track.py
@@ -199,6 +199,14 @@ class Trajectory:
                 else:
                     s_nrpts = 1 + int(s_length / s_step)
 
+        if 'kicks' in kwargs:
+            kicks_rz = kwargs['kicks'][0]
+            kicks_hkicks = kwargs['kicks'][1]
+            kicks_vkicks = kwargs['kicks'][2]
+            kicks_idx = 0
+        else:
+            kicks_idx = -1  # no kicks
+
         # inits auxiliary data structures
         self.s_step = s_step
         self.force_midplane = force_midplane
@@ -215,6 +223,13 @@ class Trajectory:
         rx, ry, rz = init_rx, init_ry, init_rz
         px, py, pz = init_px, init_py, init_pz
         while True:
+
+            # insert kicks if available
+            if kicks_idx >= 0:
+                if kicks_idx < len(kicks_rz) and rz >= kicks_rz[kicks_idx]:
+                    px += kicks_hkicks[kicks_idx]
+                    py += kicks_vkicks[kicks_idx]
+                    kicks_idx += 1
 
             # forces midplane, if the case
             if self.force_midplane:


### PR DESCRIPTION
Improvement in Runge-Kutta calculation to add thin-lens kicks along the trajectory calculation. Useful for trajectory studies of IDs with FF correctors. This script needs package `lnls-fac/idanalysis` installed.

```python3
#!/usr/bin/env python-sirius

from idanalysis import Trajectory

from utils import create_deltadata
from utils import get_config_names


def plot_corrected_trajectory(deltadata, index):    
    """Correct RK traj with FF corrs and plot results."""

    names = get_config_names(deltadata)
    config_name = names[index]
    fmap, label = deltadata.get_fieldmap(config_name)
    label = label.replace('_dGH=+0.0000', '')
    label = label.replace('_dCP=+0.0000', '')
    traj = Trajectory(label=label, fieldmap=fmap)
    title = 'RK Traj in ID\n' + label + '_Rand' + str(index+1)
    print(title.replace('\n', ' - '))
    traj.correct_posang_init(5, plot=True, title=title)


if __name__ == "__main__":
    deltadata = create_deltadata()
    plot_corrected_trajectory(deltadata, index=0)
```
![Figure_1](https://user-images.githubusercontent.com/5631815/151979695-7ecdf5ce-3ddc-41bd-90d2-87f7222fde80.png)


